### PR TITLE
Fixed using non-alphanumeric characters in default expressions

### DIFF
--- a/src/pyaml_env/parse_config.py
+++ b/src/pyaml_env/parse_config.py
@@ -35,8 +35,9 @@ def parse_config(
         """
     # pattern for global vars: look for ${word}
     # or ${word:default_value} for e.g. ':' separator
-    default_sep_pattern = f'({default_sep}\w+)?' if default_sep else ''
-    pattern = re.compile(f'.*?\${{(\w+){default_sep_pattern}}}.*?')
+    default_sep_pattern = r'(' + default_sep + '[^}^{]+)?'\
+        if default_sep else ''
+    pattern = re.compile(r'.*?\$\{([^}^{]+)' + default_sep_pattern + r'\}.*?')
     loader = yaml.SafeLoader
 
     # the tag will be used to mark where to start searching for the pattern


### PR DESCRIPTION
It has not been possible to use non-alphanumeric characters in defaults after the separator char.

Example:
```yaml
bind: !ENV ${BIND_HOST:0.0.0.0}:${BIND_PORT:8000}
```
did not resolve at all since it broke the regular expression for resolving such constructs.