### PR TITLE
 make pyyaml dependency less restrictive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyYAML==5.4.1
+PyYAML==5.*


### PR DESCRIPTION
with changes in pip 21 a new dependency resolver was introduced. We are now seeing issues like the following

The conflict is caused by:
cassandra-migrate 0.3.4 depends on PyYAML==5.3.1
pyaml-env 1.1.1 depends on PyYAML==5.4.1

this PR makes the dependency less restrictive and gives a chance to resolver to resolve dependency clash