### PR TITLE
Specify a different loader

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,4 +34,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest -m tests/
+        pytest

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ print(config)
     }
 }
 ```
-**NOTE**: Special characters like `*`, `{` etc. are not currently supported as separators. Let me know if you'd like them handled also.
+**NOTE 0**: Special characters like `*`, `{` etc. are not currently supported as separators. Let me know if you'd like them handled also.
+
+**NOTE 1**: If you set `tag` to `None`, then, the current behavior is that environment variables in all places in the yaml will be resolved (if set).
 
 ---
 
@@ -123,6 +125,39 @@ test1:
 will raise a `ValueError` because `data1:  !TEST ${ENV_TAG2}` there is no default value for `ENV_TAG2` in this line.
 
 --- 
+
+
+#### Using a different loader:
+
+The default yaml loader is `yaml.SafeLoader`. If you need to work with serialized Python objects, 
+you can specify a different loader.
+
+So given a class:
+```python
+class OtherLoadTest:
+    def __init__(self):
+        self.data0 = 'it works!'
+        self.data1 = 'this works too!'
+
+```
+
+Which has become a yaml output like the following using `yaml.dump(OtherLoadTest())`:
+```yaml
+!!python/object:__main__.OtherLoadTest
+data0: it works!
+data1: this works too!
+```
+
+You can use `parse_config` to load the object like this:
+```python
+import yaml
+from pyaml_env import parse_config
+
+other_load_test = parse_config(path='path/to/config.yaml', loader=yaml.UnsafeLoader)
+print(other_load_test)
+<__main__.OtherLoadTest object at 0x7fc38ccd5470>
+```
+---
 
 ## Long story: Load a YAML configuration file and resolve any environment variables
 

--- a/src/pyaml_env/parse_config.py
+++ b/src/pyaml_env/parse_config.py
@@ -9,7 +9,8 @@ def parse_config(
         tag='!ENV',
         default_sep=':',
         default_value='N/A',
-        raise_if_na=False
+        raise_if_na=False,
+        loader=yaml.SafeLoader
 ):
     """
         Load yaml configuration from path or from the contents of a file (data)
@@ -25,19 +26,24 @@ def parse_config(
 
         :param str path: the path to the yaml file
         :param str data: the yaml data itself as a stream
-        :param str tag: the tag to look for
+        :param str tag: the tag to look for, if None, all env variables will be
+        resolved.
         :param str default_sep: if any default values are set, use this field
         to separate them from the enironment variable name. E.g. ':' can be
         used.
         :param str default_value: the tag to look for
+        :param bool raise_if_na: raise an exception if there is no default
+        value set for the env variable.
+        :param Type[yaml.loader] loader: Specify which loader to use. Defaults to
+        yaml.SafeLoader
         :return: the dict configuration
         :rtype: dict[str, T]
         """
     default_sep = default_sep or ''
-    default_sep_pattern = r'(' + default_sep + '[^}^{]+)?' if default_sep else ''
+    default_sep_pattern = r'(' + default_sep + '[^}]+)?' if default_sep else ''
     pattern = re.compile(
         r'.*?\$\{([^}{' + default_sep + r']+)' + default_sep_pattern + r'\}.*?')
-    loader = yaml.SafeLoader
+    loader = loader or yaml.SafeLoader
 
     # the tag will be used to mark where to start searching for the pattern
     # e.g. a_key: !ENV somestring${ENV_VAR}other_stuff_follows

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, (os.getcwd()))

--- a/tests/pyaml_env_tests/test_base_config.py
+++ b/tests/pyaml_env_tests/test_base_config.py
@@ -38,8 +38,8 @@ class TestBaseConfig(unittest.TestCase):
         )
         print(base_config.a)
         print(base_config.b)
-        self.assertEquals(self.simple_data['a'], base_config.a)
-        self.assertEquals(self.simple_data['b'], base_config.b)
+        self.assertEqual(self.simple_data['a'], base_config.a)
+        self.assertEqual(self.simple_data['b'], base_config.b)
 
     def test_base_config_complex_structure(self):
         base_config = BaseConfig(self.complex_data)

--- a/tests/pyaml_env_tests/test_parse_config.py
+++ b/tests/pyaml_env_tests/test_parse_config.py
@@ -608,7 +608,7 @@ class TestParseConfig(unittest.TestCase):
         unsafe_load_instance = UnsafeLoadTest()
 
         test_data = '''
-                !!python/object:test_parse_config.UnsafeLoadTest
+                !!python/object:tests.pyaml_env_tests.test_parse_config.UnsafeLoadTest
                 data0: it works!
                 data1: this works too!
                 '''
@@ -626,7 +626,7 @@ class TestParseConfig(unittest.TestCase):
         os.environ[self.env_var2] = 'this works too, new value!'
 
         test_data = '''
-                !!python/object:test_parse_config.UnsafeLoadTest
+                !!python/object:tests.pyaml_env_tests.test_parse_config.UnsafeLoadTest
                 data0: !ENV ${ENV_TAG1}
                 data1: !ENV ${ENV_TAG2}
                 '''
@@ -643,7 +643,7 @@ class TestParseConfig(unittest.TestCase):
         os.environ[self.env_var1] = 'it works differently!'
 
         test_data = '''
-                !!python/object:test_parse_config.UnsafeLoadTest
+                !!python/object:tests.pyaml_env_tests.test_parse_config.UnsafeLoadTest
                 data0: !ENV ${ENV_TAG1}
                 data1: !ENV ${ENV_TAG2:default}
                 '''


### PR DESCRIPTION
Allow a different loader to be set. Default is `yaml.SafeLoader`.

resolves #17 