### PR TITLE
✅ Fix bug with false highlighting

### DIFF
--- a/src/pyaml_env/base_config.py
+++ b/src/pyaml_env/base_config.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class BaseConfig:
     """
     A base Config class to get
@@ -20,6 +23,9 @@ class BaseConfig:
             if isinstance(v, dict):
                 self.__dict__[k] = BaseConfig(v)
         return self.__dict__
+
+    def __getattr__(self, field_name: str) -> Any:
+        return self.__dict__[field_name]
 
     @property
     def errors(self):


### PR DESCRIPTION
I usually used parse_config-function on backend projects. But decided to try using BaseConfig-class. It seemed more convenient.

But this caused false highlighting, misunderstanding on IDE coding assistant. I use PyCharm, but I think there may be such a problem in other UDEs too. When you have a big config, it's very annoying and distracting.

Before fix:
<img width="456" alt="before_fix" src="https://user-images.githubusercontent.com/43630654/186673305-7f448e46-2af9-4083-acfe-d53bdc5f2b97.png">

To fix this, I added "__getattr__" magic-method to the BaseConfig. After this modification, the highlighting disappeared.

After fix:
<img width="456" alt="after_fix" src="https://user-images.githubusercontent.com/43630654/186674125-0ca4882a-63bb-48a3-a014-6ce640d2ad2c.png">

