### PR TITLE
Tag with datatype support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install pyaml-env
 #### Basic Usage: Environment variable parsing
 This yaml file:
 ```yaml
-databse:
+database:
   name: test_db
   username: !ENV ${DB_USER}
   password: !ENV ${DB_PASS}
@@ -99,7 +99,37 @@ print(config)
 **NOTE 1**: If you set `tag` to `None`, then, the current behavior is that environment variables in all places in the yaml will be resolved (if set).
 
 ---
+#### Datatype parsing with yaml's tag:yaml.org,2002:<datatype>
 
+```python
+# because this is not allowed:
+# data1: !TAG !!float ${ENV_TAG2:27017}
+# use tag:yaml.org,2002:datatype to convert value:
+test_data = '''
+        data0: !TAG ${ENV_TAG1}
+        data1: !TAG tag:yaml.org,2002:float ${ENV_TAG2:27017}
+        data2: !!float 1024
+        data3: !TAG ${ENV_TAG2:some_value}
+        data4: !TAG tag:yaml.org,2002:bool ${ENV_TAG2:false}
+        '''
+```
+Will become:
+```python
+os.environ['ENV_TAG1'] = "1024"
+config = parse_config(data=test_data, tag='!TAG')
+print(config)
+{
+    'data0': '1024', 
+    'data1': 27017.0, 
+    'data2': 1024.0, 
+    'data3': 'some_value', 
+    'data4': False
+}
+```
+
+[reference in yaml code](https://github.com/yaml/pyyaml/blob/master/lib/yaml/parser.py#L78)
+
+---
 #### If nothing matches: `N/A` as `default_value`:
 
 If no defaults are found and no environment variables, the `default_value` (**which is `N/A` by default**)  is used:

--- a/src/pyaml_env/parse_config.py
+++ b/src/pyaml_env/parse_config.py
@@ -53,6 +53,10 @@ def parse_config(
     # e.g. a_key: !ENV somestring${ENV_VAR}other_stuff_follows
     loader.add_implicit_resolver(tag, pattern, first=[tag])
 
+    # For inner type conversions because double tags do not work, e.g. !ENV !!float
+    type_tag = 'tag:yaml.org,2002:'
+    type_tag_pattern = re.compile(f'({type_tag}\w+\s)')
+
     def constructor_env_variables(loader, node):
         """
         Extracts the environment variable from the yaml node's value
@@ -65,13 +69,15 @@ def parse_config(
         """
         value = loader.construct_scalar(node)
         match = pattern.findall(value)  # to find all env variables in line
+        dt = ''.join(type_tag_pattern.findall(value)) or ''
+        value = value.replace(dt, '')
         if match:
             full_value = value
             for g in match:
                 curr_default_value = default_value
                 env_var_name = g
                 env_var_name_with_default = g
-                if default_sep and  isinstance(g, tuple) and len(g) > 1:
+                if default_sep and isinstance(g, tuple) and len(g) > 1:
                     env_var_name = g[0]
                     env_var_name_with_default = ''.join(g)
                     found = False
@@ -88,7 +94,13 @@ def parse_config(
                     f'${{{env_var_name_with_default}}}',
                     os.environ.get(env_var_name, curr_default_value)
                 )
+                if dt:
+                    # do one more roundtrip with the dt constructor:
+                    node.value = full_value
+                    node.tag = dt.strip()
+                    return loader.yaml_constructors[node.tag](loader, node)
             return full_value
+
         return value
 
     loader.add_constructor(tag, constructor_env_variables)

--- a/src/pyaml_env/parse_config.py
+++ b/src/pyaml_env/parse_config.py
@@ -51,7 +51,7 @@ def parse_config(
 
     # the tag will be used to mark where to start searching for the pattern
     # e.g. a_key: !ENV somestring${ENV_VAR}other_stuff_follows
-    loader.add_implicit_resolver(tag, pattern, None)
+    loader.add_implicit_resolver(tag, pattern, first=[tag])
 
     def constructor_env_variables(loader, node):
         """

--- a/tests/pyaml_env_tests/test_parse_config.py
+++ b/tests/pyaml_env_tests/test_parse_config.py
@@ -736,3 +736,27 @@ class TestParseConfig(unittest.TestCase):
         result = parse_config(data=test_data, tag=None)
         self.assertDictEqual(result, expected)
 
+        self.assertDictEqual(result, expected)
+
+    def test_numeric_values_with_type_defined(self):
+        os.environ[self.env_var1] = "1024"
+
+        test_data = '''
+                data0: !TAG ${ENV_TAG1}
+                data1: !TAG tag:yaml.org,2002:float ${ENV_TAG2:27017}
+                data2: !!float 1024
+                data3: !TAG ${ENV_TAG2:some_value}
+                data4: !TAG tag:yaml.org,2002:bool ${ENV_TAG2:false}
+                '''
+        config = parse_config(data=test_data, tag='!TAG')
+        print(config)
+        self.assertIsInstance(config['data2'], float)
+        self.assertIsInstance(config['data3'], str)
+        self.assertIsInstance(config['data1'], float)
+        self.assertIsInstance(config['data4'], bool)
+        self.assertIsInstance(config['data0'], str)
+        self.assertEqual(config['data0'], os.environ[self.env_var1])
+        self.assertEqual(config['data2'], float(os.environ[self.env_var1]))
+        self.assertEqual(config['data1'], 27017.0)
+        self.assertEqual(config['data3'], "some_value")
+        self.assertEqual(config['data4'], False)

--- a/tests/pyaml_env_tests/test_parse_config.py
+++ b/tests/pyaml_env_tests/test_parse_config.py
@@ -692,6 +692,31 @@ class TestParseConfig(unittest.TestCase):
             in str(ce.exception.problem)
         )
 
+    def test_parse_config_only_tag_env_vars_resolved(self):
+        os.environ[self.env_var1] = 'it works!'
+        os.environ[self.env_var2] = 'this works too!'
+        test_data = '''
+        test1:
+            data0: !TEST2 test1${ENV_TAG1}
+            data1: ${ENV_TAG2}
+        '''
+
+        expected = {
+           'test1': {
+               'data0': f'test1{os.environ[self.env_var1]}',
+               'data1': '${ENV_TAG2}'
+            }
+        }
+
+        # because None is used as a tag in one of the tests, it messes up expected behavior
+        # remove None from implicit resolvers:
+        if None in yaml.SafeLoader.yaml_implicit_resolvers:
+            del yaml.SafeLoader.yaml_implicit_resolvers[None]
+
+        # only ENV_TAG1 should be parsed because of !TEST2 tag
+        result = parse_config(data=test_data, tag='!TEST2')
+        self.assertDictEqual(result, expected)
+
     def test_parse_config_no_tag_all_resolved(self):
         os.environ[self.env_var1] = 'it works!'
         os.environ[self.env_var2] = 'this works too!'
@@ -709,24 +734,5 @@ class TestParseConfig(unittest.TestCase):
         }
         # all environment variables will be parsed
         result = parse_config(data=test_data, tag=None)
-        self.assertDictEqual(result, expected)
-
-    def test_parse_config_only_tag_env_vars_resolved(self):
-        os.environ[self.env_var1] = 'it works!'
-        os.environ[self.env_var2] = 'this works too!'
-        test_data = '''
-        test1:
-            data0: !TEST2 test1${ENV_TAG1}
-            data1: ${ENV_TAG2}
-        '''
-
-        expected = {
-           'test1': {
-               'data0': f'test1{os.environ[self.env_var1]}',
-               'data1': '${ENV_TAG2}'
-            }
-        }
-        # only ENV_TAG1 should be parsed because of !TEST2 tag
-        result = parse_config(data=test_data, tag='!TEST2')
         self.assertDictEqual(result, expected)
 

--- a/tests/pyaml_env_tests/test_parse_config.py
+++ b/tests/pyaml_env_tests/test_parse_config.py
@@ -704,9 +704,29 @@ class TestParseConfig(unittest.TestCase):
         expected = {
            'test1': {
                'data0': f'test1{os.environ[self.env_var1]}',
-               'data1': os.environ[self.env_var2]
+               'data1': 'this works too!'
             }
         }
+        # all environment variables will be parsed
         result = parse_config(data=test_data, tag=None)
-
         self.assertDictEqual(result, expected)
+
+    def test_parse_config_only_tag_env_vars_resolved(self):
+        os.environ[self.env_var1] = 'it works!'
+        os.environ[self.env_var2] = 'this works too!'
+        test_data = '''
+        test1:
+            data0: !TEST2 test1${ENV_TAG1}
+            data1: ${ENV_TAG2}
+        '''
+
+        expected = {
+           'test1': {
+               'data0': f'test1{os.environ[self.env_var1]}',
+               'data1': '${ENV_TAG2}'
+            }
+        }
+        # only ENV_TAG1 should be parsed because of !TEST2 tag
+        result = parse_config(data=test_data, tag='!TEST2')
+        self.assertDictEqual(result, expected)
+


### PR DESCRIPTION
Resolves #26 by adding subparsing of type with the use of [`tag:yaml.org,2002:`](https://github.com/yaml/pyyaml/blob/master/lib/yaml/parser.py#L78) 