### PR TITLE
Fix SyntaxWarning: invalid escape sequence.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/src/pyaml_env/parse_config.py
+++ b/src/pyaml_env/parse_config.py
@@ -55,7 +55,7 @@ def parse_config(
 
     # For inner type conversions because double tags do not work, e.g. !ENV !!float
     type_tag = 'tag:yaml.org,2002:'
-    type_tag_pattern = re.compile(f'({type_tag}\w+\s)')
+    type_tag_pattern = re.compile(rf'({type_tag}\w+\s)')
 
     def constructor_env_variables(loader, node):
         """


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.12.html

A backslash-character pair that is not a valid escape sequence now generates a SyntaxWarning, instead of DeprecationWarning. For example, re.compile("\d+\.\d+") now emits a SyntaxWarning ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, SyntaxError will eventually be raised, instead of SyntaxWarning. (Contributed by Victor Stinner in gh-98401.)

Fixes: https://github.com/mkaranasou/pyaml_env/issues/35